### PR TITLE
add: Also tag the latest build for alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ $(foreach version,$(VERSIONS),$(eval $(call test-version,$(version))))
 
 tag-latest: $(BUILD_LATEST_DEP)
 	$(DOCKER) image tag $(REPO_NAME)/$(IMAGE_NAME):$(LATEST_VERSION) $(REPO_NAME)/$(IMAGE_NAME):latest
+	$(DOCKER) image tag $(REPO_NAME)/$(IMAGE_NAME):$(LATEST_VERSION)-alpine $(REPO_NAME)/$(IMAGE_NAME):alpine
 
 
 ### RULES FOR PUSHING ###


### PR DESCRIPTION
It is quite common, and upstream postgres does so as well, to also tag a 'latest' for alpine. In this case, this would result in `postgis:alpine` being the latest stable alpine release. This makes it easier (albeit riskier) to track the latest stable postgis release. The risk should be acceptable however, as the same risk would be taken when tracking `postgis:latest` so it really is up to the user.